### PR TITLE
Feature/add ldap sync and vpn

### DIFF
--- a/charts/bitwardenrs/Chart.yaml
+++ b/charts/bitwardenrs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bitwardenrs
 description: Unofficial Bitwarden compatible server written in Rust
 type: application
-version: 2.0.1
+version: 2.1.0
 appVersion: 1.18.0
 keywords:
   - bitwarden

--- a/charts/bitwardenrs/README.md
+++ b/charts/bitwardenrs/README.md
@@ -64,7 +64,13 @@ helm install bitwardenrs k8s-at-home/bitwardenrs -f values.yaml
 
 ## Custom configuration
 
-N/A
+### Ldap-Sync
+
+Via [vividboarder/bitwarden_rs_ldap](https://github.com/ViViDboarder/bitwarden_rs_ldap) it is possible to fetch your user base from an ldap server of your choosing. If ldapSync.enabled is true you will get the opportunity to use an ldap server which could assist with inviting users.
+
+With the ldapSync.extraContainers and ldapSync.extraVolumes values you're able to customize the ldap-sync pod.
+
+For example with environments that require a secure connection to an LDAP server you can add a VPN container, which enables the sync container to communicate over a VPN.
 
 ## Values
 
@@ -129,6 +135,11 @@ N/A
 | ingress.hosts[0].host | string | `"chart-example.local"` |  |
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` |  |
+| ldapSync.configToml | string | `""` |  |
+| ldapSync.enabled | bool | false |  |
+| ldapSync.existingSecret | string | `""` |  |
+| ldapSync.extraContainers | list | `[]` |  |
+| ldapSync.extraVolumes | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | persistence.accessMode | string | `"ReadWriteOnce"` |  |
@@ -155,6 +166,12 @@ N/A
 All notable changes to this application Helm chart will be documented in this file but does not include changes from our common library. To read those click [here](https://github.com/k8s-at-home/library-charts/tree/main/charts/stable/common#changelog).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+### [2.1.0]
+
+#### Added
+
+- Ldap sync support
 
 ### [2.0.1]
 

--- a/charts/bitwardenrs/templates/_helpers.tpl
+++ b/charts/bitwardenrs/templates/_helpers.tpl
@@ -52,6 +52,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Ldap labels
+*/}}
+{{- define "bitwardenrsLdap.labels" -}}
+helm.sh/chart: {{ include "bitwardenrs.chart" . }}
+{{ include "bitwardenrsLdap.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "bitwardenrsLdap.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bitwardenrs.name" . }}-ldap
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "bitwardenrs.serviceAccountName" -}}

--- a/charts/bitwardenrs/templates/deployment-ldapsync.yaml
+++ b/charts/bitwardenrs/templates/deployment-ldapsync.yaml
@@ -1,0 +1,46 @@
+{{- if and (.Values.ldapSync.enabled) (not .Values.ldapSync.existinSecret) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "bitwardenrsLdap.labels" . | nindent 4 }}
+  name: {{ include "bitwardenrs.name" . }}-ldap
+spec:
+  selector:
+    matchLabels:
+      {{- include "bitwardenrsLdap.selectorLabels" . | nindent 6 }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        {{- include "bitwardenrsLdap.selectorLabels" . | nindent 8 }}
+    spec:
+      initContainers:
+      containers:
+        - name: ldap-sync
+          image: vividboarder/bitwarden_rs_ldap
+          imagePullPolicy: Always 
+          env:
+            - name: CONFIG_PATH
+              value: "/etc/bitwarden/config.toml"
+            - name: RUST_BACKTRACE
+              value: "full"
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/bitwarden
+              name: {{ if .Values.ldapSync.existingSecret.enabled }}{{ .Values.ldapSync.existingSecret.secretName }}{{ end }}
+              readOnly: true
+      {{- if .Values.ldapSync.extraContainers }}
+      {{- toYaml .Values.ldapSync.extraContainers | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: {{ include "bitwardenrs.name" . }}-ldap
+          secret:
+            defaultMode: 420
+            secretName: {{ if .Values.ldapSync.existingSecret.enabled }}{{ .Values.ldapSync.existingSecret.secretName }}{{ else }}{{ include "bitwardenrs.name" . }}-ldap{{ end }}
+        {{- if .Values.ldapSync.extraVolumes }}
+        {{- toYaml .Values.ldapSync.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/bitwardenrs/templates/secret-ldapsync.yaml
+++ b/charts/bitwardenrs/templates/secret-ldapsync.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Values.ldapSync.enabled) (not .Values.ldapSync.existinSecret) }}
+apiVersion: v1
+data:
+  config.toml: {{ .Values.ldapSync.configToml | b64enc }}
+kind: Secret
+metadata:
+  labels:
+  {{- include "bitwardenrsLdap.labels" . | nindent 4 }}
+  name: {{ include "bitwardenrs.name" . -}}-ldap
+type: Opaque
+{{- end }}

--- a/charts/bitwardenrs/templates/secret.yaml
+++ b/charts/bitwardenrs/templates/secret.yaml
@@ -4,8 +4,8 @@ kind: Secret
 metadata:
   name: {{ template "bitwardenrs.fullname" . }}
   labels:
-  {{- include "bitwardenrs.labels" . | nindent 4 }}
+    {{- include "bitwardenrs.labels" . | nindent 4 }}
 type: Opaque
 data:
   admin-token: {{ randAlphaNum 48 | b64enc | quote }}
-  {{- end }}
+{{- end }}

--- a/charts/bitwardenrs/values.yaml
+++ b/charts/bitwardenrs/values.yaml
@@ -176,3 +176,46 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+ldapSync:
+  enabled: false
+  # Configuration file for ldap server connection
+  configToml: |-
+    bitwarden_url = "http://bitwarden:80"
+    bitwarden_admin_token = "admin"
+    ldap_host = "ldap"
+    ldap_bind_dn = "cn=admin,dc=example,dc=org"
+    ldap_bind_password = "admin"
+    ldap_search_base_dn = "dc=example,dc=org"
+    ldap_search_filter = "(&(objectClass=*)(uid=*))"
+    ldap_sync_interval_seconds = 10
+  # Use existing secret for config.toml
+  existingSecret: ""
+  # Add extra containers
+  extraContainers: []
+    # - name: vpn
+    #   image: dperson/openvpn-client
+    #   command: ["/bin/sh","-c"]
+    #   args: ["openvpn --config 'vpn/client.ovpn' --script-security 3;"]
+    #   stdin: true
+    #   tty: true
+    #   securityContext:
+    #     privileged: true
+    #     capabilities:
+    #       add:
+    #         - NET_ADMIN
+    #   env:
+    #     - name: DE
+    #       value: "Berlin"
+    #   volumeMounts:
+    #     - name: bitwardenrs-vpn
+    #       mountPath: /vpn/client.ovpn
+    #       subPath: client.ovpn
+  # Add extra volumes
+  extraVolumes: []
+    # - name: bitwarden-vpn
+    #   secret:
+    #     secretName: bitwardenrs-vpn
+    #     items:
+    #       - key: client.ovpn
+    #         path: client.ovpn


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] (optional) Chart is using our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency.
- [ ] (optional) Variables are documented in the README.md

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
